### PR TITLE
Support dual stack IPv4 and IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DIGITAL OCEAN DYNAMIC IP API CLIENT
 A simple script in Go language to automatically update Digital ocean DNS records if you have a dynamic IP. Since it can be compiled on any platform, you can use it along with raspberrypi etc.
 
-To find your Dynamic IP, this program will call out to https://diagnostic.opendns.com/myip.
+To find your Dynamic IP, this program will call out to https://ipv4bot.whatismyipaddress.com for ipv4 addresses and https://ipv6bot.whatismyipaddress.com for ipv6 addresses. This is to support dual-stack environments.
 
 ## requirements
 Requires Git and Go for building.
@@ -21,6 +21,8 @@ create a file ".digitalocean-dynamic-ip.json"(dot prefix to hide the file) and p
 {
   "apikey": "samplekeydasjkdhaskjdhrwofihsamplekey",
   "doPageSize" : 20,
+  "useIPv4": true,
+  "useIPv6": false,
   "domains": [
     {
       "domain": "example.com",
@@ -47,6 +49,8 @@ create a file ".digitalocean-dynamic-ip.json"(dot prefix to hide the file) and p
 The TTL can optionally be updated if passed in the configuration. Digital Ocean has a minimum TTL of 30 seconds. The `type` and the `name` must match existing records in the Digital Ocean DNS configuration. Only `types` of `A` and `AAAA` allowed at the moment.
 
 If you want to reduce the number of calls made to the digital ocean API and have more than 20 DNS records in your domain, you can adjust the `doPageSize` parameter. By default, Digital Ocean returns 20 records per page.
+
+By default, the configuration checks both IPv4 and IPv6 addresses assuming your provider set up your connection as dual stack. If you know you only have ipv4 or ipv6 you can disable using one or the other in the config. To disable one or the other, set the `useIPv4` or `useIPv6` settings to `false`. If the options aren't present, or are set to `null`, then the configuration assumes a value of `true`.
 
 ```bash
 #run

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ create a file ".digitalocean-dynamic-ip.json"(dot prefix to hide the file) and p
   "doPageSize" : 20,
   "useIPv4": true,
   "useIPv6": false,
+  "allowIPv4InIPv6": false,
   "domains": [
     {
       "domain": "example.com",
@@ -48,9 +49,11 @@ create a file ".digitalocean-dynamic-ip.json"(dot prefix to hide the file) and p
 ```
 The TTL can optionally be updated if passed in the configuration. Digital Ocean has a minimum TTL of 30 seconds. The `type` and the `name` must match existing records in the Digital Ocean DNS configuration. Only `types` of `A` and `AAAA` allowed at the moment.
 
-If you want to reduce the number of calls made to the digital ocean API and have more than 20 DNS records in your domain, you can adjust the `doPageSize` parameter. By default, Digital Ocean returns 20 records per page.
+If you want to reduce the number of calls made to the digital ocean API and have more than 20 DNS records in your domain, you can adjust the `doPageSize` parameter. By default, Digital Ocean returns 20 records per page. Digital Ocean has a max page size of 200 items.
 
 By default, the configuration checks both IPv4 and IPv6 addresses assuming your provider set up your connection as dual stack. If you know you only have ipv4 or ipv6 you can disable using one or the other in the config. To disable one or the other, set the `useIPv4` or `useIPv6` settings to `false`. If the options aren't present, or are set to `null`, then the configuration assumes a value of `true`.
+
+The `allowIPv4InIPv6` configuration option will allow adding an IPv4 address to be used in a AAAA record for IPv6 lookups.
 
 ```bash
 #run

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # DIGITAL OCEAN DYNAMIC IP API CLIENT
 A simple script in Go language to automatically update Digital ocean DNS records if you have a dynamic IP. Since it can be compiled on any platform, you can use it along with raspberrypi etc.
 
+To find your Dynamic IP, this program will call out to https://diagnostic.opendns.com/myip.
+
 ## requirements
 Requires Git and Go for building.
 
 Requires that the record already exists in DigitalOcean's DNS so that it can be updated.
 (manually find your IP and add it to DO's DNS it will later be updated)
+
+Requires a Digital Ocean API key that can be created at https://cloud.digitalocean.com/account/api/tokens.
 
 ## Usage
 ```bash
@@ -16,6 +20,7 @@ create a file ".digitalocean-dynamic-ip.json"(dot prefix to hide the file) and p
 ```json
 {
   "apikey": "samplekeydasjkdhaskjdhrwofihsamplekey",
+  "doPageSize" : 20,
   "domains": [
     {
       "domain": "example.com",
@@ -31,18 +36,30 @@ create a file ".digitalocean-dynamic-ip.json"(dot prefix to hide the file) and p
       "records": [
         {
           "name": "subdomainOrRecord2",
-          "type": "A"
+          "type": "A",
+          "TTL": 30
         }
       ]
     }
   ]
 }
 ```
+The TTL can optionally be updated if passed in the configuration. Digital Ocean has a minimum TTL of 30 seconds. The `type` and the `name` must match existing records in the Digital Ocean DNS configuration. Only `types` of `A` and `AAAA` allowed at the moment.
+
+If you want to reduce the number of calls made to the digital ocean API and have more than 20 DNS records in your domain, you can adjust the `doPageSize` parameter. By default, Digital Ocean returns 20 records per page.
+
 ```bash
 #run
 go build digitalocean-dynamic-ip.go
 ./digitalocean-dynamic-ip
 ```
+
+Optionally, you can create the configuration file with any name wherever you want, and pass it as a command line argument:
+````bash
+#run
+./digitalocean-dynamic-ip /path/tp/my/config.json
+```
+
 You can either set this to run periodically with a cronjob or use your own method.
 ```bash
 # run crontab -e

--- a/digitalocean-dynamic-ip.go
+++ b/digitalocean-dynamic-ip.go
@@ -3,9 +3,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"strconv"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -17,10 +22,13 @@ func checkError(err error) {
 	}
 }
 
+var config ClientConfig
+
 // ClientConfig : configuration json
 type ClientConfig struct {
-	APIKey  string   `json:"apiKey"`
-	Domains []Domain `json:"domains"`
+	APIKey     string   `json:"apiKey"`
+	DOPageSize int      `json:"doPageSize"`
+	Domains    []Domain `json:"domains"`
 }
 
 // Domain : domains to be changed
@@ -31,27 +39,76 @@ type Domain struct {
 
 // DNSRecord : Modifyiable DNS record
 type DNSRecord struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
-	Data string `json:"data"`
-	Type string `json:"type"`
+	ID       int64   `json:"id"`
+	Type     string  `json:"type"`
+	Name     string  `json:"name"`
+	Priority *int    `json:"priority"`
+	Port     *int    `json:"port"`
+	Weight   *int    `json:"weight"`
+	TTL      int     `json:"ttl"`
+	Flags    *uint8  `json:"flags"`
+	Tag      *string `json:"tag"`
+	Data     string  `json:"data"`
 }
 
 // DOResponse : DigitalOcean DNS Records response.
 type DOResponse struct {
 	DomainRecords []DNSRecord `json:"domain_records"`
+	Meta          struct {
+		Total int `json:"total"`
+	} `json:"meta"`
+	Links struct {
+		Pages struct {
+			First    string `json:"first"`
+			Previous string `json:"prev"`
+			Next     string `json:"next"`
+			Last     string `json:"last"`
+		} `json:"pages"`
+	} `json:"links"`
 }
 
 //GetConfig : get configuration file ~/.digitalocean-dynamic-ip.json
 func GetConfig() ClientConfig {
-	homeDirectory, err := homedir.Dir()
-	checkError(err)
-	getfile, err := ioutil.ReadFile(homeDirectory + "/.digitalocean-dynamic-ip.json")
+	cmdHelp := flag.Bool("h", false, "Show the help message")
+	cmdHelp2 := flag.Bool("help", false, "Show the help message")
+	flag.Parse()
+
+	if *cmdHelp || *cmdHelp2 {
+		usage()
+		os.Exit(1)
+	}
+
+	configFile := ""
+	if len(flag.Args()) == 0 {
+		var err error
+		configFile, err = homedir.Dir()
+		checkError(err)
+		configFile += "/.digitalocean-dynamic-ip.json"
+	} else {
+		configFile = flag.Args()[0]
+	}
+
+	getfile, err := ioutil.ReadFile(configFile)
 	checkError(err)
 	var config ClientConfig
 	json.Unmarshal(getfile, &config)
 	checkError(err)
 	return config
+}
+
+func usage() {
+	os.Stdout.WriteString(fmt.Sprintf("To use this program you can specify the following command options:\n"+
+		"-h | -help\n\tShow this help message\n"+
+		"[config_file]\n\tlocation of the configuration file\n\n"+
+		"If the [config_file] parameter is not passed, then the default\n"+
+		"config location of ~/.digitalocean-dynamic-ip.json will be used.\n\n"+
+		"example usages:\n\t%[1]s -help\n"+
+		"\t%[1]s\n"+
+		"\t%[1]s %[2]s\n"+
+		"",
+		os.Args[0],
+		"/path/to/my/config.json",
+	))
 }
 
 //CheckLocalIP : get current IP of server.
@@ -65,18 +122,33 @@ func CheckLocalIP() string {
 }
 
 //GetDomainRecords : Get DNS records of current domain.
-func GetDomainRecords(apiKey string, domain string) DOResponse {
+func GetDomainRecords(domain string) []DNSRecord {
+	ret := make([]DNSRecord, 0)
+	var page DOResponse
+	pageParam := ""
+	// 20 is the default page size
+	if config.DOPageSize > 0 && config.DOPageSize != 20 {
+		pageParam = "?per_page=" + strconv.Itoa(config.DOPageSize)
+	}
+	for url := "https://api.digitalocean.com/v2/domains/" + url.PathEscape(domain) + "/records" + pageParam; url != ""; url = page.Links.Pages.Next {
+		page = getPage(url)
+		ret = append(ret, page.DomainRecords...)
+	}
+	return ret
+}
+
+func getPage(url string) DOResponse {
+	log.Println(url)
 	client := &http.Client{}
-	request, err := http.NewRequest("GET",
-		"https://api.digitalocean.com/v2/domains/"+domain+"/records",
-		nil)
+	request, err := http.NewRequest("GET", url, nil)
 	checkError(err)
 	request.Header.Add("Content-type", "Application/json")
-	request.Header.Add("Authorization", "Bearer "+apiKey)
+	request.Header.Add("Authorization", "Bearer "+config.APIKey)
 	response, err := client.Do(request)
 	checkError(err)
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
+	// log.Print(string(body))
 	var jsonDOResponse DOResponse
 	e := json.Unmarshal(body, &jsonDOResponse)
 	checkError(e)
@@ -84,37 +156,84 @@ func GetDomainRecords(apiKey string, domain string) DOResponse {
 }
 
 // UpdateRecords : Update DNS records of domain
-func UpdateRecords(apiKey string, domain string, currentIP string, currentRecords DOResponse, toUpdateRecords []DNSRecord) {
-	for _, currentRecord := range currentRecords.DomainRecords {
-		for _, toUpdateRecord := range toUpdateRecords {
-			if toUpdateRecord.Name == currentRecord.Name && toUpdateRecord.Type == currentRecord.Type && currentIP != currentRecord.Data {
-				update := []byte(`{"type":"` + toUpdateRecord.Type + `","data":"` + currentIP + `"}`)
+func UpdateRecords(domain string, ip net.IP, toUpdateRecords []DNSRecord) {
+	currentIP := ip.String()
+	isIpv6 := ip.To4() == nil
+	if !isIpv6 {
+		// make sure we are using a v4 format
+		currentIP = ip.To4().String()
+	}
+	log.Printf("%s: %d to update\n", domain, len(toUpdateRecords))
+	updated := 0
+	doRecords := GetDomainRecords(domain)
+	// look for the item to update
+	if len(doRecords) < 1 {
+		log.Printf("%s: No DNS records found", domain)
+		return
+	}
+	log.Printf("%s: %d DNS records found", domain, len(doRecords))
+	for _, toUpdateRecord := range toUpdateRecords {
+		if toUpdateRecord.Type != "A" && toUpdateRecord.Type != "AAAA" {
+			log.Fatalf("%s: Unsupported type (Only A and AAAA records supported) for updates %+v", domain, toUpdateRecord)
+		}
+		if isIpv6 && toUpdateRecord.Type == "A" {
+			log.Fatalf("%s: You are trying to update an IPV4 A record with an IPV6 address: new ip: %s, config: %+v", domain, currentIP, toUpdateRecord)
+		}
+		if !isIpv6 && toUpdateRecord.Type == "AAAA" {
+			log.Fatalf("%s: You are trying to update an IPV6 A record with an IPV4 address: new ip: %s, config: %+v", domain, currentIP, toUpdateRecord)
+		}
+		if toUpdateRecord.ID > 0 {
+			// update the record directly. skip the extra search
+			log.Fatalf("%s: Unable to directly update records yet. Record: %+v", domain, toUpdateRecord)
+		}
+
+		log.Printf("%s: trying to update `%s` : `%s`", domain, toUpdateRecord.Type, toUpdateRecord.Name)
+		for _, doRecord := range doRecords {
+			//log.Printf("%s: checking `%s` : `%s`", domain, doRecord.Type, doRecord.Name)
+			if doRecord.Name == toUpdateRecord.Name && doRecord.Type == toUpdateRecord.Type {
+				if doRecord.Data == currentIP && (toUpdateRecord.TTL < 30 || doRecord.TTL == toUpdateRecord.TTL) {
+					log.Printf("%s: IP/TTL did not change %+v", domain, doRecord)
+					continue
+				}
+				log.Printf("%s: updating %+v", domain, doRecord)
+				// set the IP address
+				doRecord.Data = currentIP
+				if toUpdateRecord.TTL >= 30 && doRecord.TTL != toUpdateRecord.TTL {
+					doRecord.TTL = toUpdateRecord.TTL
+				}
+				update, err := json.Marshal(doRecord)
+				checkError(err)
 				client := &http.Client{}
 				request, err := http.NewRequest("PUT",
-					"https://api.digitalocean.com/v2/domains/"+domain+"/records/"+strconv.FormatInt(int64(currentRecord.ID), 10),
+					"https://api.digitalocean.com/v2/domains/"+url.PathEscape(domain)+"/records/"+strconv.FormatInt(int64(doRecord.ID), 10),
 					bytes.NewBuffer(update))
 				checkError(err)
 				request.Header.Set("Content-Type", "application/json")
-				request.Header.Add("Authorization", "Bearer "+apiKey)
+				request.Header.Add("Authorization", "Bearer "+config.APIKey)
 				response, err := client.Do(request)
 				checkError(err)
 				defer response.Body.Close()
 				body, err := ioutil.ReadAll(response.Body)
-				log.Printf("DO update response for %s: %s\n", currentRecord.Name, string(body))
+				log.Printf("%s: DO update response for %s: %s\n", domain, doRecord.Name, string(body))
+				updated++
 			}
 		}
+
 	}
+	log.Printf("%s: %d of %d records updated\n", domain, updated, len(toUpdateRecords))
 }
 
 func main() {
-	config := GetConfig()
+	config = GetConfig()
 	currentIP := CheckLocalIP()
-
-	for _, domains := range config.Domains {
-		domainName := domains.Domain
-		apiKey := config.APIKey
-		currentDomainRecords := GetDomainRecords(apiKey, domainName)
-		log.Println(domainName)
-		UpdateRecords(apiKey, domainName, currentIP, currentDomainRecords, domains.Records)
+	ip := net.ParseIP(currentIP)
+	if ip == nil {
+		log.Fatalf("current IP address `%s` is not a valid IP address", currentIP)
+	}
+	for _, domain := range config.Domains {
+		domainName := domain.Domain
+		log.Printf("%s: START\n", domainName)
+		UpdateRecords(domainName, ip, domain.Records)
+		log.Printf("%s: END\n", domainName)
 	}
 }

--- a/digitalocean-dynamic-ip.sample.json
+++ b/digitalocean-dynamic-ip.sample.json
@@ -3,6 +3,7 @@
   "doPageSize": 20,
   "useIPv4": true,
   "useIPv6": true,
+  "allowIPv4InIPv6": false,
   "domains": [
     {
       "domain": "example.com",

--- a/digitalocean-dynamic-ip.sample.json
+++ b/digitalocean-dynamic-ip.sample.json
@@ -1,5 +1,6 @@
 {
   "apikey": "samplekeydasjkdhaskjdhrwofihsamplekey",
+  "doPageSize" : 20,
   "domains": [
     {
       "domain": "example.com",

--- a/digitalocean-dynamic-ip.sample.json
+++ b/digitalocean-dynamic-ip.sample.json
@@ -1,6 +1,8 @@
 {
   "apikey": "samplekeydasjkdhaskjdhrwofihsamplekey",
-  "doPageSize" : 20,
+  "doPageSize": 20,
+  "useIPv4": true,
+  "useIPv6": true,
   "domains": [
     {
       "domain": "example.com",


### PR DESCRIPTION
Builds on the `correct_paging` branch (#3) to support dual stack environments that have both public IPv4 and IPv6 addresses.

* Updates the README with more examples for new features
* Changes web API calls that get the current public IP to get explicit v4 or v6 addresses
* Adds a configuration option to allow v4 addresses to be used in AAAA records